### PR TITLE
HHVM fails to clone DateTime [Failing test only]

### DIFF
--- a/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
+++ b/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
@@ -166,6 +166,7 @@ class InstantiatorTest extends PHPUnit_Framework_TestCase
             array(__CLASS__),
             array('Doctrine\\Instantiator\\Instantiator'),
             array('PharException'),
+            array('DateTime'),
             array('DoctrineTest\\InstantiatorTestAsset\\SimpleSerializableAsset'),
             array('DoctrineTest\\InstantiatorTestAsset\\PharExceptionAsset'),
             array('DoctrineTest\\InstantiatorTestAsset\\UnCloneableAsset'),


### PR DESCRIPTION
No idea...!

It looks like HHVM dies when trying to clone a DateTime that has been instantiated with instantiator.

```
davem@wes:instantiator:failing-hhvm-test$ hhvm --version
HipHop VM 3.3.0 (rel)
Compiler: tags/HHVM-3.3.0-0-g0a3cfb87b8a353fc7e1d15374f4adc413e37aba9
Repo schema: 9a391d9a03e15fccba1cde6d35c05b7cdd380238
Extension API: 20140829
davem@wes:instantiator:failing-hhvm-test$ hhvm vendor/bin/phpunit
PHPUnit 4.3.1 by Sebastian Bergmann.

Configuration read from /home/davem/src/instantiator/phpunit.xml.dist

..........
Fatal error: A null object pointer was used. in /home/davem/src/instantiator/src/Doctrine/Instantiator/Instantiator.php on line 73
```

Though it's happy to do so with a DateTime that has been constructed normally:

```
davem@wes:instantiator:failing-hhvm-test$ cat t.php
<?php

$a = new DateTime();
$b = clone $a;

echo $b->format('r');
davem@wes:instantiator:failing-hhvm-test$ hhvm t.php
Mon, 06 Oct 2014 23:28:45 +0100%
```
