### PR TITLE
PSR-4, retaining original folder structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "athletic/athletic":         "~0.1.8"
     },
     "autoload": {
-        "psr-0": {
-            "Doctrine\\Instantiator\\": "src"
+        "psr-4": {
+            "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
PSR-0 is deprecated, so we should use PSR-4. For BC, I've retained the original folder structure.
