### PR TITLE
Remove the hhvm-nightly job from the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 5.5
   - 5.6
   - hhvm
-  - hhvm-nightly
 
 before_script:
   - ./.travis.install.sh
@@ -21,7 +20,3 @@ script:
 
 after_script:
   - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then wget https://scrutinizer-ci.com/ocular.phar; php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
-
-matrix:
-  allow_failures:
-    - php: hhvm-nightly


### PR DESCRIPTION
hhvm-nightly is not available anymore on Travis for now, because HHVM dropped support for Ubuntu 10.04