### PR TITLE
Cannot instantiate final class if it extends internal

### DIFF
--- a/src/Doctrine/Instantiator/Instantiator.php
+++ b/src/Doctrine/Instantiator/Instantiator.php
@@ -197,7 +197,7 @@ final class Instantiator implements InstantiatorInterface
     private function isInstantiableViaReflection(ReflectionClass $reflectionClass)
     {
         if (\PHP_VERSION_ID >= 50600) {
-            return ! ($reflectionClass->isInternal() && $reflectionClass->isFinal());
+            return ! ($this->hasInternalAncestors($reflectionClass) && $reflectionClass->isFinal());
         }
 
         return \PHP_VERSION_ID >= 50400 && ! $this->hasInternalAncestors($reflectionClass);

--- a/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
+++ b/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
@@ -169,6 +169,7 @@ class InstantiatorTest extends PHPUnit_Framework_TestCase
             array('PharException'),
             array('DoctrineTest\\InstantiatorTestAsset\\SimpleSerializableAsset'),
             array('DoctrineTest\\InstantiatorTestAsset\\ExceptionAsset'),
+            array('DoctrineTest\\InstantiatorTestAsset\\FinalExceptionAsset'),
             array('DoctrineTest\\InstantiatorTestAsset\\PharExceptionAsset'),
             array('DoctrineTest\\InstantiatorTestAsset\\UnCloneableAsset'),
             array('DoctrineTest\\InstantiatorTestAsset\\XMLReaderAsset'),

--- a/tests/DoctrineTest/InstantiatorTestAsset/FinalExceptionAsset.php
+++ b/tests/DoctrineTest/InstantiatorTestAsset/FinalExceptionAsset.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineTest\InstantiatorTestAsset;
+
+use BadMethodCallException;
+use Exception;
+
+/**
+ * Test asset that extends an internal PHP base exception
+ *
+ * @author Marco Pivetta <ocramius@gmail.com>
+ */
+final class FinalExceptionAsset extends Exception
+{
+    /**
+     * Constructor - should not be called
+     *
+     * @throws BadMethodCallException
+     */
+    public function __construct()
+    {
+        throw new BadMethodCallException('Not supposed to be called!');
+    }
+}


### PR DESCRIPTION
For some reason in PHP > 5.6 you're checking a class isn't final and internal, instead you should be checking it's not final w/ internal ancestors (as in the case below for PHP > 5.4)

This is linked to https://github.com/phpspec/phpspec/issues/704