### PR TITLE
Typehint className in instantiate method

### DIFF
--- a/src/Doctrine/Instantiator/Instantiator.php
+++ b/src/Doctrine/Instantiator/Instantiator.php
@@ -43,7 +43,7 @@ final class Instantiator implements InstantiatorInterface
     /**
      * {@inheritDoc}
      */
-    public function instantiate($className)
+    public function instantiate(string $className)
     {
         if (isset(self::$cachedCloneables[$className])) {
             return clone self::$cachedCloneables[$className];

--- a/src/Doctrine/Instantiator/InstantiatorInterface.php
+++ b/src/Doctrine/Instantiator/InstantiatorInterface.php
@@ -16,5 +16,5 @@ interface InstantiatorInterface
      *
      * @throws ExceptionInterface
      */
-    public function instantiate($className);
+    public function instantiate(string $className);
 }


### PR DESCRIPTION
I think this was not Typehinted for BC break reasons but since in ` src/Doctrine/Instantiator/Instantiator.php ` the method ` instantiate ` calls the ` buildAndCacheFromFactory ` method where className is Typehinted as ` string ` , I don't see in which scenario ` $className ` could not be a ` string `.

Moreover, in the interface the $className parameter is already described as ` string ` in the annotation.

If we accept classes that implement ` InstantiatorInterface ` but don't use a ` string ` as parameter (unlikely) then we need to remove the annotation. Right ?
