### PR TITLE
Remove parameter annotation

### DIFF
--- a/src/Doctrine/Instantiator/InstantiatorInterface.php
+++ b/src/Doctrine/Instantiator/InstantiatorInterface.php
@@ -10,8 +10,6 @@ use Doctrine\Instantiator\Exception\ExceptionInterface;
 interface InstantiatorInterface
 {
     /**
-     * @param string $className
-     *
      * @return object
      *
      * @throws ExceptionInterface


### PR DESCRIPTION
There is no sense to let this annotation if we accept classes that implement ` InstantiatorInterface` with a parameter different than ` string ` 