### PR TITLE
Fix error_handler type hints

### DIFF
--- a/src/Doctrine/Instantiator/Instantiator.php
+++ b/src/Doctrine/Instantiator/Instantiator.php
@@ -132,7 +132,7 @@ final class Instantiator implements InstantiatorInterface
      */
     private function checkIfUnSerializationIsSupported(ReflectionClass $reflectionClass, string $serializedString) : void
     {
-        set_error_handler(static function ($code, $message, $file, $line) use ($reflectionClass, & $error) : void {
+        set_error_handler(static function (int $code, string $message, string $file, int $line) use ($reflectionClass, & $error) : bool {
             $error = UnexpectedValueException::fromUncleanUnSerialization(
                 $reflectionClass,
                 $message,
@@ -140,6 +140,8 @@ final class Instantiator implements InstantiatorInterface
                 $file,
                 $line
             );
+
+            return true;
         });
 
         try {


### PR DESCRIPTION
Hi,

I've updated the error_handler typehinting, mostly the return type declarations.
From php.net documentation, the `error_handler` should return a bool and not a void (https://www.php.net/manual/en/function.set-error-handler.php).

Thanks to psalm 👍 

```
ERROR: InvalidArgument - src/Doctrine/Instantiator/Instantiator.php:135:27 - Argument 1 of set_error_handler expects null|callable(int, string, string=, int=, array<array-key, mixed>=):bool, Closure(int, string, string, int):void provided
        set_error_handler(static function (int $code, string $message, string $file, int $line) use ($reflectionClass, & $error) : void {
            $error = UnexpectedValueException::fromUncleanUnSerialization(
                $reflectionClass,
                $message,
                $code,
                $file,
                $line
            );
        });
```