### PR TITLE
Adds support of internal child class instantiation

### DIFF
--- a/src/Doctrine/Instantiator/Instantiator.php
+++ b/src/Doctrine/Instantiator/Instantiator.php
@@ -7,7 +7,9 @@ use Doctrine\Instantiator\Exception\UnexpectedValueException;
 use Exception;
 use ReflectionClass;
 use ReflectionException;
+use Serializable;
 use function class_exists;
+use function is_subclass_of;
 use function restore_error_handler;
 use function set_error_handler;
 use function sprintf;
@@ -94,7 +96,7 @@ final class Instantiator implements InstantiatorInterface
 
         $serializedString = sprintf(
             '%s:%d:"%s":0:{}',
-            is_subclass_of($className, \Serializable::class) ? self::SERIALIZATION_FORMAT_USE_UNSERIALIZER : self::SERIALIZATION_FORMAT_AVOID_UNSERIALIZER,
+            is_subclass_of($className, Serializable::class) ? self::SERIALIZATION_FORMAT_USE_UNSERIALIZER : self::SERIALIZATION_FORMAT_AVOID_UNSERIALIZER,
             strlen($className),
             $className
         );
@@ -130,7 +132,7 @@ final class Instantiator implements InstantiatorInterface
      */
     private function checkIfUnSerializationIsSupported(ReflectionClass $reflectionClass, string $serializedString) : void
     {
-        set_error_handler(static function (int $code, string $message, string $file, int $line) use ($reflectionClass, & $error) : bool {
+        set_error_handler(static function (int $code, string $message, string $file, int $line) use ($reflectionClass, &$error) : bool {
             $error = UnexpectedValueException::fromUncleanUnSerialization(
                 $reflectionClass,
                 $message,

--- a/src/Doctrine/Instantiator/Instantiator.php
+++ b/src/Doctrine/Instantiator/Instantiator.php
@@ -2,6 +2,7 @@
 
 namespace Doctrine\Instantiator;
 
+use ArrayIterator;
 use Doctrine\Instantiator\Exception\InvalidArgumentException;
 use Doctrine\Instantiator\Exception\UnexpectedValueException;
 use Exception;
@@ -195,6 +196,8 @@ final class Instantiator implements InstantiatorInterface
      */
     private function isSafeToClone(ReflectionClass $reflection) : bool
     {
-        return $reflection->isCloneable() && ! $reflection->hasMethod('__clone');
+        return $reflection->isCloneable()
+            && ! $reflection->hasMethod('__clone')
+            && ! $reflection->isSubclassOf(ArrayIterator::class);
     }
 }

--- a/src/Doctrine/Instantiator/Instantiator.php
+++ b/src/Doctrine/Instantiator/Instantiator.php
@@ -94,7 +94,7 @@ final class Instantiator implements InstantiatorInterface
 
         $serializedString = sprintf(
             '%s:%d:"%s":0:{}',
-            self::SERIALIZATION_FORMAT_AVOID_UNSERIALIZER,
+            is_subclass_of($className, \Serializable::class) ? self::SERIALIZATION_FORMAT_USE_UNSERIALIZER : self::SERIALIZATION_FORMAT_AVOID_UNSERIALIZER,
             strlen($className),
             $className
         );

--- a/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
+++ b/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use function str_replace;
 use function uniqid;
+use DoctrineTest\InstantiatorTestAsset\SerializableFinalInternalChildAssset;
 
 /**
  * Tests for {@see \Doctrine\Instantiator\Instantiator}
@@ -124,6 +125,7 @@ class InstantiatorTest extends TestCase
             [SerializableArrayObjectAsset::class],
             [WakeUpNoticesAsset::class],
             [UnserializeExceptionArrayObjectAsset::class],
+            [SerializableFinalInternalChildAssset::class],
         ];
     }
 

--- a/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
+++ b/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
@@ -13,6 +13,7 @@ use DoctrineTest\InstantiatorTestAsset\ExceptionAsset;
 use DoctrineTest\InstantiatorTestAsset\FinalExceptionAsset;
 use DoctrineTest\InstantiatorTestAsset\PharExceptionAsset;
 use DoctrineTest\InstantiatorTestAsset\SerializableArrayObjectAsset;
+use DoctrineTest\InstantiatorTestAsset\SerializableFinalInternalChildAsset;
 use DoctrineTest\InstantiatorTestAsset\SimpleSerializableAsset;
 use DoctrineTest\InstantiatorTestAsset\SimpleTraitAsset;
 use DoctrineTest\InstantiatorTestAsset\UnCloneableAsset;
@@ -26,7 +27,6 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use function str_replace;
 use function uniqid;
-use DoctrineTest\InstantiatorTestAsset\SerializableFinalInternalChildAssset;
 
 /**
  * Tests for {@see \Doctrine\Instantiator\Instantiator}
@@ -125,7 +125,7 @@ class InstantiatorTest extends TestCase
             [SerializableArrayObjectAsset::class],
             [WakeUpNoticesAsset::class],
             [UnserializeExceptionArrayObjectAsset::class],
-            [SerializableFinalInternalChildAssset::class],
+            [SerializableFinalInternalChildAsset::class],
         ];
     }
 

--- a/tests/DoctrineTest/InstantiatorTestAsset/SerializableFinalInternalChildAsset.php
+++ b/tests/DoctrineTest/InstantiatorTestAsset/SerializableFinalInternalChildAsset.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace DoctrineTest\InstantiatorTestAsset;
+
+use ArrayIterator;
+
+final class SerializableFinalInternalChildAsset extends ArrayIterator
+{
+}

--- a/tests/DoctrineTest/InstantiatorTestAsset/SerializableFinalInternalChildAssset.php
+++ b/tests/DoctrineTest/InstantiatorTestAsset/SerializableFinalInternalChildAssset.php
@@ -1,8 +1,0 @@
-<?php
-declare(strict_types=1);
-
-namespace DoctrineTest\InstantiatorTestAsset;
-
-final class SerializableFinalInternalChildAssset extends \ArrayIterator
-{
-}

--- a/tests/DoctrineTest/InstantiatorTestAsset/SerializableFinalInternalChildAssset.php
+++ b/tests/DoctrineTest/InstantiatorTestAsset/SerializableFinalInternalChildAssset.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace DoctrineTest\InstantiatorTestAsset;
+
+final class SerializableFinalInternalChildAssset extends \ArrayIterator
+{
+}


### PR DESCRIPTION
Related to https://github.com/doctrine/instantiator/issues/39

This is my attempt to resolve a [long on-going issue](https://github.com/phpspec/phpspec/issues/1124) on the phpspec repository, taking inspiration on the [SF VarExporter component](https://github.com/symfony/symfony/commit/3b931fe6c9bae7300c914b68801ad79a06efbf27).

I do not see any other missing testcases, however feel free to let me know if you think about some, I will happily add them.

/cc @ciaranmcnulty @Ocramius @mikeSimonson