### PR TITLE
Add missing versions to .doctrine-project.json

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,8 +6,8 @@
     "codePath": "/src",
     "versions": [
         {
-            "name": "1.1",
-            "branchName": "master",
+            "name": "1.3",
+            "branchName": "1.3.x",
             "slug": "latest",
             "aliases": [
                 "current",
@@ -17,10 +17,19 @@
             "current": true
         },
         {
+            "name": "1.2",
+            "branchName": "1.2.x",
+            "slug": "1.2"
+        },
+        {
+            "name": "1.1",
+            "branchName": "1.1.x",
+            "slug": "1.1"
+        },
+        {
             "name": "1.0",
             "branchName": "1.0.x",
             "slug": "1.0"
         }
     ]
 }
-


### PR DESCRIPTION
Important: 1.2.x and 1.1.x branches need to be added before this PR can be merged.

This PR adds the missing versions of 1.1 and 1.2. It also marks 1.3 as maintained and current version.