### PR TITLE
Require-dev also supports phpstan ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "ext-pdo":                   "*",
         "doctrine/coding-standard":  "^8.0",
         "phpbench/phpbench":         "^0.13 || 1.0.0-alpha2",
-        "phpstan/phpstan":           "^0.12",
-        "phpstan/phpstan-phpunit":   "^0.12",
+        "phpstan/phpstan-phpunit":   "^0.12 || ^1.0",
         "phpunit/phpunit":           "^7.0 || ^8.0 || ^9.0",
         "vimeo/psalm": "^4.11"
     },


### PR DESCRIPTION
Since phpstan is already at "stable" 1.x version would be cool to this library do not block others by requiring only old 0.12