### PR TITLE
Fail nicely on enum FQCNs

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,4 +51,13 @@
         <exclude-pattern>src/Doctrine/Instantiator/Exception/ExceptionInterface.php</exclude-pattern>
         <exclude-pattern>src/Doctrine/Instantiator/InstantiatorInterface.php</exclude-pattern>
     </rule>
+
+    <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
+        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
+        <exclude-pattern>tests/DoctrineTest/InstantiatorTestAsset/SimpleEnumAsset.php</exclude-pattern>
+    </rule>
+    <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
+        <!-- see https://github.com/squizlabs/PHP_CodeSniffer/issues/3474 -->
+        <exclude-pattern>tests/DoctrineTest/InstantiatorTestAsset/SimpleEnumAsset.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/Doctrine/Instantiator/Exception/InvalidArgumentException.php
+++ b/src/Doctrine/Instantiator/Exception/InvalidArgumentException.php
@@ -17,11 +17,11 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements E
     public static function fromNonExistingClass(string $className): self
     {
         if (interface_exists($className)) {
-            return new self(sprintf('The provided type "%s" is an interface, and can not be instantiated', $className));
+            return new self(sprintf('The provided type "%s" is an interface, and cannot be instantiated', $className));
         }
 
         if (trait_exists($className)) {
-            return new self(sprintf('The provided type "%s" is a trait, and can not be instantiated', $className));
+            return new self(sprintf('The provided type "%s" is a trait, and cannot be instantiated', $className));
         }
 
         return new self(sprintf('The provided class "%s" does not exist', $className));
@@ -35,8 +35,16 @@ class InvalidArgumentException extends BaseInvalidArgumentException implements E
     public static function fromAbstractClass(ReflectionClass $reflectionClass): self
     {
         return new self(sprintf(
-            'The provided class "%s" is abstract, and can not be instantiated',
+            'The provided class "%s" is abstract, and cannot be instantiated',
             $reflectionClass->getName()
+        ));
+    }
+
+    public static function fromEnum(string $className): self
+    {
+        return new self(sprintf(
+            'The provided class "%s" is an enum, and cannot be instantiated',
+            $className
         ));
     }
 }

--- a/src/Doctrine/Instantiator/Instantiator.php
+++ b/src/Doctrine/Instantiator/Instantiator.php
@@ -12,12 +12,15 @@ use ReflectionException;
 use Serializable;
 
 use function class_exists;
+use function enum_exists;
 use function is_subclass_of;
 use function restore_error_handler;
 use function set_error_handler;
 use function sprintf;
 use function strlen;
 use function unserialize;
+
+use const PHP_VERSION_ID;
 
 final class Instantiator implements InstantiatorInterface
 {
@@ -146,6 +149,10 @@ final class Instantiator implements InstantiatorInterface
     {
         if (! class_exists($className)) {
             throw InvalidArgumentException::fromNonExistingClass($className);
+        }
+
+        if (PHP_VERSION_ID >= 80100 && enum_exists($className, false)) {
+            throw InvalidArgumentException::fromEnum($className);
         }
 
         $reflection = new ReflectionClass($className);

--- a/tests/DoctrineTest/InstantiatorTest/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/DoctrineTest/InstantiatorTest/Exception/InvalidArgumentExceptionTest.php
@@ -33,7 +33,7 @@ class InvalidArgumentExceptionTest extends TestCase
         $exception = InvalidArgumentException::fromNonExistingClass(SimpleTraitAsset::class);
 
         self::assertSame(
-            sprintf('The provided type "%s" is a trait, and can not be instantiated', SimpleTraitAsset::class),
+            sprintf('The provided type "%s" is a trait, and cannot be instantiated', SimpleTraitAsset::class),
             $exception->getMessage()
         );
     }
@@ -44,7 +44,7 @@ class InvalidArgumentExceptionTest extends TestCase
 
         self::assertSame(
             sprintf(
-                'The provided type "%s" is an interface, and can not be instantiated',
+                'The provided type "%s" is an interface, and cannot be instantiated',
                 InstantiatorInterface::class
             ),
             $exception->getMessage()
@@ -58,7 +58,7 @@ class InvalidArgumentExceptionTest extends TestCase
 
         self::assertSame(
             sprintf(
-                'The provided class "%s" is abstract, and can not be instantiated',
+                'The provided class "%s" is abstract, and cannot be instantiated',
                 AbstractClassAsset::class
             ),
             $exception->getMessage()

--- a/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
+++ b/tests/DoctrineTest/InstantiatorTest/InstantiatorTest.php
@@ -14,6 +14,7 @@ use DoctrineTest\InstantiatorTestAsset\FinalExceptionAsset;
 use DoctrineTest\InstantiatorTestAsset\PharExceptionAsset;
 use DoctrineTest\InstantiatorTestAsset\SerializableArrayObjectAsset;
 use DoctrineTest\InstantiatorTestAsset\SerializableFinalInternalChildAsset;
+use DoctrineTest\InstantiatorTestAsset\SimpleEnumAsset;
 use DoctrineTest\InstantiatorTestAsset\SimpleSerializableAsset;
 use DoctrineTest\InstantiatorTestAsset\SimpleTraitAsset;
 use DoctrineTest\InstantiatorTestAsset\UnCloneableAsset;
@@ -21,6 +22,7 @@ use DoctrineTest\InstantiatorTestAsset\UnserializeExceptionArrayObjectAsset;
 use DoctrineTest\InstantiatorTestAsset\WakeUpNoticesAsset;
 use DoctrineTest\InstantiatorTestAsset\XMLReaderAsset;
 use Exception;
+use Generator;
 use PDORow;
 use PharException;
 use PHPUnit\Framework\TestCase;
@@ -28,6 +30,8 @@ use stdClass;
 
 use function str_replace;
 use function uniqid;
+
+use const PHP_VERSION_ID;
 
 /**
  * Tests for {@see \Doctrine\Instantiator\Instantiator}
@@ -142,15 +146,19 @@ class InstantiatorTest extends TestCase
     /**
      * Provides a list of instantiable classes (existing)
      *
-     * @return string[][]
+     * @psalm-return Generator<string, array{string}>
      */
-    public function getInvalidClassNames(): array
+    public function getInvalidClassNames(): Generator
     {
-        return [
-            [self::class . str_replace('.', '', uniqid('', true))],
-            [InstantiatorInterface::class],
-            [AbstractClassAsset::class],
-            [SimpleTraitAsset::class],
-        ];
+        yield 'invalid string' => [self::class . str_replace('.', '', uniqid('', true))];
+        yield 'interface' => [InstantiatorInterface::class];
+        yield 'abstract class' => [AbstractClassAsset::class];
+        yield 'trait' => [SimpleTraitAsset::class];
+
+        if (PHP_VERSION_ID < 80100) {
+            return;
+        }
+
+        yield 'enum' => [SimpleEnumAsset::class];
     }
 }

--- a/tests/DoctrineTest/InstantiatorTestAsset/SimpleEnumAsset.php
+++ b/tests/DoctrineTest/InstantiatorTestAsset/SimpleEnumAsset.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DoctrineTest\InstantiatorTestAsset;
+
+enum SimpleEnumAsset
+{
+    case Foo;
+    case Bar;
+}


### PR DESCRIPTION
When being presented with an enum FQCN, the `Instantiator` currently tries to create an instance via reflection and triggers an `Error`. This PR turns this error into a nice `Doctrine\Instantiator\Exception\InvalidArgumentException` which is the same exception we already get for interfaces, traits and abstract classes.

An alternative could be to simply return the first case of the enum. The problem with that approach is that the instantiator currently guarantees that each call will yield a different instance. That wouldn't be the case for enums then.