### PR TITLE
Simplify composer command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library provides a way of avoiding usage of constructors when instantiating
 The suggested installation method is via [composer](https://getcomposer.org/):
 
 ```sh
-php composer.phar require "doctrine/instantiator:~1.0.3"
+composer require doctrine/instantiator
 ```
 
 ## Usage


### PR DESCRIPTION
I think, in 2022 we can assume that people have a global installation of composer or at least know how to call the composer binary installed on their machine. Moreover, the suggested version constraint is way outdated. Since composer will pick a proper constraint anyway, I'd just remove it.

This is also consistent with the command line we use in our [documentation](https://github.com/doctrine/instantiator/blob/1.4.x/docs/en/index.rst#installation).