### PR TITLE
Avoid duplicate aliases / slugs

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -8,11 +8,8 @@
         {
             "name": "2.0",
             "branchName": "2.0.x",
-            "slug": "current",
-            "aliases": [
-                "latest",
-                "stable"
-            ],
+            "slug": "2.0",
+            "aliases": ["latest"],
             "maintained": true,
             "current": true
         },


### PR DESCRIPTION
Marking a branch as current is equivalent to creating a `current` and `stable` alias for it.