### PR TITLE
PHP 8.3 support tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,5 +14,5 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@3.0.0"
     with:
-      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
+      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
       composer-root-version: "1.4"

--- a/.github/workflows/phpbench.yml
+++ b/.github/workflows/phpbench.yml
@@ -22,6 +22,8 @@ jobs:
       matrix:
         php-version:
           - "8.1"
+          - "8.2"
+          - "8.3"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Motivation:
Verify if the package is compatible with PHP 8.3. If not then find and list the issue needs to be taken care.