### PR TITLE
Adapt ignore error message

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,7 @@ parameters:
     ignoreErrors:
         # PHPStan is unable to infer the return type of unserialize() in this case.
         -
-            message: '#Method Doctrine\\Instantiator\\Instantiator\:\:buildFactory\(\) should return callable\(\): T of object but returns Closure\(\): mixed\.#'
+            message: '#Method Doctrine\\Instantiator\\Instantiator\:\:buildFactory\(\) should return callable\(\): T but returns Closure\(\): mixed\.#'
             path: 'src/Doctrine/Instantiator/Instantiator.php'
 
         # dynamic properties confuse static analysis

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,4 +13,12 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <!-- Issue about &error; should go away with Psalm v6 -->
+        <UndefinedVariable>
+            <errorLevel type="suppress">
+                <file name="src/Doctrine/Instantiator/Instantiator.php" />
+            </errorLevel>
+        </UndefinedVariable>
+    </issueHandlers>
 </psalm>


### PR DESCRIPTION
Looks like the "of object" part is no longer mentioned in recent PHPStan versions.