### PR TITLE
Mark all 1.x versions as unmaintained

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -34,17 +34,20 @@
         {
             "name": "1.2",
             "branchName": "1.2.x",
-            "slug": "1.2"
+            "slug": "1.2",
+            "maintained": false
         },
         {
             "name": "1.1",
             "branchName": "1.1.x",
-            "slug": "1.1"
+            "slug": "1.1",
+            "maintained": false
         },
         {
             "name": "1.0",
             "branchName": "1.0.x",
-            "slug": "1.0"
+            "slug": "1.0",
+            "maintained": false
         }
     ]
 }


### PR DESCRIPTION
This seems to have been overlooked, because subsequent 1.x versions are already marked as unmaintained.