### PR TITLE
Specify schema for PHPCS configuration file

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset>
+<ruleset
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
     <arg name="basepath" value="."/>
     <arg name="extensions" value="php"/>
     <arg name="parallel" value="80"/>


### PR DESCRIPTION
It helps tooling such as language servers figure out what is a valid XML configuration file.